### PR TITLE
Better handling of the missing offsets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>ir.sahab</groupId>
   <artifactId>smart-commit-kafka-consumer</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
 
   <repositories>
     <repository>

--- a/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
+++ b/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
@@ -1,11 +1,16 @@
 package ir.sahab.kafkaconsumer;
 
 import ir.sahab.logthrottle.LogThrottle;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 /**
  * Tracker for Kafka consumed records which are delivered to their targets. Here is the problem

--- a/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
+++ b/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
@@ -258,6 +258,9 @@ public class OffsetTracker {
          */
         void track(int offset) {
             if (offset < margin) {
+                logThrottle.logger("not-tracked-region").warn("A track received but this offset is "
+                        + "not in the tracked region of the page. It is valid if it has been a "
+                        + "re-balance recently. offset: {}, page margin: {}", offset, margin);
                 return;
             }
             int effectiveOffset = offset - margin;

--- a/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
+++ b/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
@@ -258,7 +258,7 @@ public class OffsetTracker {
          */
         void track(int offset) {
             if (offset < margin) {
-                throw new IllegalStateException("Out of order offset detected. Consumer offsets should be tracked in order.");
+                return;
             }
             int effectiveOffset = offset - margin;
             // Set the bit representing this offset, indicating the offset is tracked but not acked yet

--- a/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
+++ b/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
@@ -258,7 +258,7 @@ public class OffsetTracker {
          */
         void track(int offset) {
             if (offset < margin) {
-                return;
+                throw new IllegalStateException("Out of order offset detected. Consumer offsets should be tracked in order.");
             }
             int effectiveOffset = offset - margin;
             // Set the bit representing this offset, indicating the offset is tracked but not acked yet

--- a/src/test/java/ir/sahab/kafkaconsumer/OffsetTrackerTest.java
+++ b/src/test/java/ir/sahab/kafkaconsumer/OffsetTrackerTest.java
@@ -110,7 +110,7 @@ public class OffsetTrackerTest {
         // Track calls which opens the first page: [0..2]
         offsetTracker.track(partition, 1);
 
-        // Track calls which opens the second page: [3..5]
+        // Track calls which opens the second page: [3..5] and makes a gap for the first page
         // Offset 1 completes the first page because the next offsets are inside the recognized gap.
         offsetTracker.track(partition, 3);
 
@@ -125,7 +125,7 @@ public class OffsetTrackerTest {
     }
 
     @Test
-    public void testGapMiddleOfPage() {
+    public void testPageWithMiddleGap() {
         final int pageSize = 3;
         final int maxOpenPagesPerPartition = 2;
         final OffsetTracker offsetTracker = new OffsetTracker(pageSize, maxOpenPagesPerPartition);


### PR DESCRIPTION
If Kafka topic that this consumer operates on has a retention policy, in some situations there can be gaps is offsets we read from Kafka.
These gaps make some pages to not get completed and therefore the consumer group's offset won't get committed properly.
Eventually these not-completed pages cause the consumer to not progress and then the consumer stops consuming records and hangs forever.