### PR TITLE
Implement a new way to handle gaps (#28)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>ir.sahab</groupId>
   <artifactId>smart-commit-kafka-consumer</artifactId>
-  <version>1.4.3</version>
+  <version>1.5.0</version>
 
   <repositories>
     <repository>

--- a/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
+++ b/src/main/java/ir/sahab/kafkaconsumer/OffsetTracker.java
@@ -121,50 +121,91 @@ public class OffsetTracker {
         private final Map<Long /*page index*/, PageTracker> pageTrackers = new HashMap<>();
         private final SortedSet<Long /*page index*/> completedPages = new TreeSet<>();
         private long lastConsecutivePageIndex;
+        private long lastOpenedPageIndex;
+        private long lastTrackedOffset;
         private volatile int openPagesSize = 0;
         private volatile int completedPagesSize = 0;
 
         public PartitionTracker(int partition, long initialOffset) {
-            lastConsecutivePageIndex = offsetToPage(initialOffset) - 1;
             String partitionLabel = String.valueOf(partition);
             metricRegistry.register(LabeledMetric.name(OPEN_PAGES).label(PARTITION, partitionLabel).toString(),
                     (Gauge<Integer>) () -> openPagesSize);
             metricRegistry.register(LabeledMetric.name(COMPLETED_PAGES).label(PARTITION, partitionLabel).toString(),
                     (Gauge<Integer>) () -> completedPagesSize);
+
+            openNewPageForOffset(initialOffset);
+            lastConsecutivePageIndex = offsetToPage(initialOffset) - 1;
+            lastTrackedOffset = initialOffset - 1;
         }
 
         boolean track(long offset) {
             long pageIndex = offsetToPage(offset);
-            int pageOffset = (int) (offset % pageSize);
-            PageTracker pageTracker = pageTrackers.get(pageIndex);
-            if (pageTracker == null) {
-                if (pageTrackers.size() >= maxOpenPagesPerPartition) {
+
+            // Normal case: offsets coming in order.
+            if (offset - lastTrackedOffset == 1) {
+                // If offset belongs to a new page but we are full, reject the offset.
+                if (pageIndex > lastOpenedPageIndex && !openNewPageForOffset(offset)) {
                     return false;
                 }
-                pageTracker = new PageTracker(pageSize, pageOffset);
-                pageTrackers.put(pageIndex, pageTracker);
-                openPagesSize = pageTrackers.size();
-                // Since all the offsets will be tracked in order, we don't expect any more tracks for previous page.
-                markPageNoMoreTracks(pageIndex - 1);
+                lastTrackedOffset = offset;
+                return true;
             }
-            pageTracker.track(pageOffset);
+
+            // Special case: we have seen an old offset that we have already passed.
+            // Potential reason: there is a rebalance recently and it is an offset buffered before rebalance.
+            if (offset <= lastTrackedOffset) {
+                logThrottle.logger("old-offset").warn("An offset received that is already tracked. "
+                        + "It is valid if it has been a re-balance recently. "
+                        + "offset: {}", offset);
+                return true;
+            }
+
+            // Special case: we have seen an offset greater than expectation and there is a gap.
+            // Potential reason: there is a cleanup by Kafka according to retention policy.
+            // Our reaction: we fill the gap and assume missed records are acked before. We have handled it for
+            // both cases that the gap is just in last page or the gap includes new pages.
+            logThrottle.logger("offset-gap").warn("An offset received greater than expectation and there is a gap "
+                    + "between records. It is valid if there is a cleanup for these offsets recently. "
+                    + "offset: {}, expectedOffset: {}", offset, lastTrackedOffset + 1);
+            final PageTracker lastPage = pageTrackers.get(lastOpenedPageIndex);
+            // When the gap is just in last page:
+            if (pageIndex == lastOpenedPageIndex) {
+                    lastPage.bulkAck(offsetToPageOffset(lastTrackedOffset + 1), offsetToPageOffset(offset));
+                    return true;
+            }
+
+            // When the gap includes new pages:
+            // We handle it by 3 actions: creating a new page for offsets after the gap, filling the last page
+            // whose tail is inside the gap, resetting the completed pages.
+            final long lastPageIndexBeforeGap = lastOpenedPageIndex;
+            final long lastOffsetBeforeGap = lastTrackedOffset;
+            if (!openNewPageForOffset(offset)) {
+                return false;
+            }
+            // Fill the gap of last page and check if it's completed.
+            boolean completed = lastPage.bulkAck(offsetToPageOffset(lastOffsetBeforeGap + 1), pageSize);
+            if (completed) {
+                pageTrackers.remove(lastPageIndexBeforeGap);
+            }
+            // We clear the completed pages for two reasons: 1. There is no point in committing deleted offsets.
+            // 2. To make sure after this gap, we can construct consecutive pages in completed pages again.
+            completedPages.clear();
+            completedPagesSize = 0;
+            lastConsecutivePageIndex = lastOpenedPageIndex - 1;
+            lastTrackedOffset = offset;
             return true;
         }
 
-        /**
-         * Marks a page with the noMoreTracks flag and handles necessary stuff if it gets completed.
-         */
-        private void markPageNoMoreTracks(long pageIndex) {
-            PageTracker pageTracker = pageTrackers.get(pageIndex);
-            if (pageTracker != null) {
-                pageTracker.markNoMoreTracks();
-                if (pageTracker.isCompleted()) {
-                    pageTrackers.remove(pageIndex);
-                    if (pageIndex > lastConsecutivePageIndex) {
-                        completedPages.add(pageIndex);
-                    }
-                }
+        private boolean openNewPageForOffset(long offset) {
+            if ((pageTrackers.size() + completedPages.size()) >= maxOpenPagesPerPartition) {
+                return false;
             }
+            long pageIndex = offsetToPage(offset);
+            int margin = offsetToPageOffset(offset);
+            pageTrackers.put(pageIndex, new PageTracker(pageSize, margin));
+            openPagesSize = pageTrackers.size();
+            lastOpenedPageIndex = pageIndex;
+            return true;
         }
 
         /**
@@ -184,7 +225,7 @@ public class OffsetTracker {
                         + "offset: {}", offset);
                 return OptionalLong.empty();
             }
-            int pageOffset = (int) (offset % pageSize);
+            int pageOffset = offsetToPageOffset(offset);
             if (!pageTracker.ack(pageOffset)) {
                 return OptionalLong.empty();
             }
@@ -196,7 +237,7 @@ public class OffsetTracker {
             if (pageIndex <= lastConsecutivePageIndex) {
                 logThrottle.logger("redundant-page").warn("An ack received which completes a page "
                                 + "but the page is already completed. It is valid if it has "
-                                + "been a re-balance recently. offset: {}, completed page index: {}",
+                                + "been a re-balance or cleanup recently. offset: {}, completed page index: {}",
                         offset, pageIndex);
                 return OptionalLong.empty();
             }
@@ -239,6 +280,10 @@ public class OffsetTracker {
         private long offsetToPage(long offset) {
             return offset / pageSize;
         }
+
+        private int offsetToPageOffset(long offset) {
+            return (int)   (offset % pageSize);
+        }
     }
 
     /**
@@ -246,11 +291,10 @@ public class OffsetTracker {
      * class for each page when it starts tracking the first offset of that page.
      */
     private class PageTracker {
-        private final int effectiveSize;
         private final int margin;
         private final BitSet bits;
-        private int maxTrackedOffset;
-        private boolean noMoreTracks = false;
+        private final int effectiveSize;
+        private int firstUnackedOffset;
 
         /**
          * Constructs a page tracker.
@@ -262,33 +306,12 @@ public class OffsetTracker {
         PageTracker(int size, int margin) {
             this.effectiveSize = size - margin;
             this.margin = margin;
-            this.maxTrackedOffset = 0;
+            this.firstUnackedOffset = 0;
             bits = new BitSet(effectiveSize);
         }
 
         int getMargin() {
             return margin;
-        }
-
-        /**
-         * Tracks an offset within this page. All the tracked offsets should be acked before this page can be considered
-         * as completed.
-         *
-         * @param offset pageOffset to track
-         */
-        void track(int offset) {
-            int effectiveOffset = offset - margin;
-            if (effectiveOffset < maxTrackedOffset) {
-                logThrottle.logger("not-tracked-region").warn("A backward offset is tracked but this offset is "
-                        + "not in the tracked region of the page. It is valid if it has been a "
-                        + "re-balance recently. offset: {}, previous offset: {}", offset, margin + maxTrackedOffset);
-                return;
-            }
-            // Set the bit representing this offset, indicating the offset is tracked but not acked yet
-            bits.set(effectiveOffset);
-            if (effectiveOffset > this.maxTrackedOffset) {
-                this.maxTrackedOffset = effectiveOffset;
-            }
         }
 
         /**
@@ -306,28 +329,23 @@ public class OffsetTracker {
                 return false;
             }
 
-            // Clear the bit representing this offset.
+            // Set the bit representing this offset.
             int effectiveOffset = offset - margin;
-            bits.clear(effectiveOffset);
+            bits.set(effectiveOffset);
+
+            // Find number of consecutive offsets which are acked starting from margin.
+            if (effectiveOffset == firstUnackedOffset) {
+                firstUnackedOffset = bits.nextClearBit(firstUnackedOffset);
+            }
 
             // Return true if all expected offsets are acked.
-            return isCompleted();
+            return (firstUnackedOffset == effectiveSize);
         }
 
-        /**
-         * Calling this method indicates that this PageTracker should not expect any more new offset tracks and any
-         * missing untracked offset is a gap. We may have a gap in rare cases for example in the case when some records
-         * are gone due to retention.
-         */
-        void markNoMoreTracks() {
-            this.noMoreTracks = true;
-        }
-
-        /**
-         * @return true if all tracked offsets are acked and no more tracks are expected.
-         */
-        boolean isCompleted() {
-            return bits.isEmpty() && (maxTrackedOffset == effectiveSize - 1 || noMoreTracks);
+        boolean bulkAck(int from, int to) {
+            bits.set(from - margin, to - margin);
+            firstUnackedOffset = bits.nextClearBit(firstUnackedOffset);
+            return firstUnackedOffset == effectiveSize;
         }
     }
 }

--- a/src/main/java/ir/sahab/kafkaconsumer/SmartCommitKafkaConsumer.java
+++ b/src/main/java/ir/sahab/kafkaconsumer/SmartCommitKafkaConsumer.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SmartCommitKafkaConsumer<K, V> implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(SmartCommitKafkaConsumer.class);
-    private static final LogThrottle logThrottle = new LogThrottle(logger);
+    private static final LogThrottle logThrottle = new LogThrottle(logger, 15_000);
 
     private static final int POLL_TIMEOUT_MILLIS = 10;
 

--- a/src/test/java/ir/sahab/kafkaconsumer/OffsetTrackerTest.java
+++ b/src/test/java/ir/sahab/kafkaconsumer/OffsetTrackerTest.java
@@ -3,6 +3,7 @@ package ir.sahab.kafkaconsumer;
 import java.util.OptionalLong;
 import java.util.stream.IntStream;
 import com.codahale.metrics.MetricRegistry;
+import ir.sahab.dropwizardmetrics.LabeledMetric;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -104,26 +105,60 @@ public class OffsetTrackerTest {
 
     @Test
     public void testPageWithTailGap() {
-        final int pageSize = 3;
+        final int pageSize = 4;
         final int maxOpenPagesPerPartition = 2;
-        final OffsetTracker offsetTracker = new OffsetTracker(pageSize, maxOpenPagesPerPartition, new MetricRegistry());
+        MetricRegistry metricRegistry = new MetricRegistry();
+        final OffsetTracker offsetTracker = new OffsetTracker(pageSize, maxOpenPagesPerPartition, metricRegistry);
+        final int partition = 0;
+
+        // Track calls which opens the first page: [0..3]
+        offsetTracker.track(partition, 1);
+        offsetTracker.track(partition, 2);
+        Assert.assertEquals(1, getOpenPageSize(metricRegistry, partition));
+
+        // Track calls which opens the second page: [4..7] and makes a gap for the first page
+        offsetTracker.track(partition, 6);
+        offsetTracker.track(partition, 7);
+        Assert.assertEquals(2, getOpenPageSize(metricRegistry, partition));
+
+        // Offset 2 completes the second page but it must not be committed cause its offset is deleted in Kafka.
+        Assert.assertFalse(offsetTracker.ack(partition, 1).isPresent());
+        Assert.assertEquals(2, getOpenPageSize(metricRegistry, partition));
+        Assert.assertFalse(offsetTracker.ack(partition, 2).isPresent());
+        Assert.assertEquals(1, getOpenPageSize(metricRegistry, partition));
+
+        // Offset 7 should complete the page and the new page should be committed.
+        Assert.assertFalse(offsetTracker.ack(partition, 6).isPresent());
+        Assert.assertEquals(8, offsetTracker.ack(partition, 7).getAsLong());
+
+        Assert.assertEquals(0, getCompletedPageSize(metricRegistry, partition));
+        Assert.assertEquals(0, getOpenPageSize(metricRegistry, partition));
+    }
+
+    @Test
+    public void testMultiplePageGap() {
+        final int pageSize = 3;
+        final int maxOpenPagesPerPartition = 4;
+        MetricRegistry metricRegistry = new MetricRegistry();
+        final OffsetTracker offsetTracker = new OffsetTracker(pageSize, maxOpenPagesPerPartition, metricRegistry);
         final int partition = 0;
 
         // Track calls which opens the first page: [0..2]
         offsetTracker.track(partition, 1);
 
-        // Track calls which opens the second page: [3..5] and makes a gap for the first page
-        // Offset 1 completes the first page because the next offsets are inside the recognized gap.
-        offsetTracker.track(partition, 3);
+        // Track calls which opens the 4th page: [9..11] and makes a gap for the first page
+        // Ack 11 should complete the page and commit the offset cause older pages should be ignored.
+        offsetTracker.track(partition, 10);
+        offsetTracker.track(partition, 11);
+        Assert.assertFalse(offsetTracker.ack(partition, 10).isPresent());
+        Assert.assertEquals(2, getOpenPageSize(metricRegistry, partition));
+        Assert.assertEquals(12, offsetTracker.ack(partition, 11).getAsLong());
+        Assert.assertEquals(1, getOpenPageSize(metricRegistry, partition));
+        Assert.assertEquals(0, getCompletedPageSize(metricRegistry, partition));
 
-
-        OptionalLong offsetToCommit;
-        offsetToCommit = offsetTracker.ack(partition, 1);
-        Assert.assertTrue(offsetToCommit.isPresent());
-        Assert.assertEquals(3, offsetToCommit.getAsLong());
-
-        offsetToCommit = offsetTracker.ack(partition, 3);
-        Assert.assertFalse(offsetToCommit.isPresent());
+        Assert.assertFalse(offsetTracker.ack(partition, 1).isPresent());
+        Assert.assertEquals(0, getOpenPageSize(metricRegistry, partition));
+        Assert.assertEquals(0, getCompletedPageSize(metricRegistry, partition));
     }
 
     @Test
@@ -260,7 +295,7 @@ public class OffsetTrackerTest {
         offsetTracker.track(partition, 3);  // From first session
 
         // These acks make the pages partially completed [0..2].
-        IntStream.range(0,3).forEach(i -> offsetTracker.track(partition, i)); // For first session
+        IntStream.range(0,3).forEach(i -> offsetTracker.ack(partition, i)); // For first session
 
         // We will reset offset tracker to simulate partitions re-balance.
         offsetTracker.reset();
@@ -295,5 +330,19 @@ public class OffsetTrackerTest {
         offsetToCommit = offsetTracker.ack(partition, 11);
         Assert.assertEquals(12, offsetToCommit.getAsLong());
 
+    }
+
+    private static int getCompletedPageSize(MetricRegistry metricRegistry, int partition) {
+        String metricName = LabeledMetric.name(OffsetTracker.COMPLETED_PAGES)
+                .label(OffsetTracker.PARTITION, String.valueOf(partition))
+                .toString();
+        return (int) metricRegistry.getGauges().get(metricName).getValue();
+    }
+
+    private static int getOpenPageSize(MetricRegistry metricRegistry, int partition) {
+        String metricName = LabeledMetric.name(OffsetTracker.OPEN_PAGES)
+                .label(OffsetTracker.PARTITION, String.valueOf(partition))
+                .toString();
+        return (int) metricRegistry.getGauges().get(metricName).getValue();
     }
 }


### PR DESCRIPTION
- Fixed a bug in corner cases of handing the gap (Implemented a new way to handle gaps in page tracker)
- Fixed a bug in preventing too many uncommitted pages (Completed pages but not committed ones are now counted as open pages in  forcing maxOpenPages config)